### PR TITLE
Add Sovereign Grace scaffold and FastAPI streaming router with circuit breaker

### DIFF
--- a/server/scripts/generate_sovereign_king.sh
+++ b/server/scripts/generate_sovereign_king.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP_DIR="lucy21-sovereign-king"
+
+echo "Initializing Sovereign Grace scaffold..."
+mkdir -p "$APP_DIR"/{core,pro,sdk_bridge,docs,telemetry}
+touch "$APP_DIR/telemetry/requests.log" "$APP_DIR/telemetry/errors.log"
+
+cat << 'PY' > "$APP_DIR/core/api_router.py"
+import asyncio
+import time
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from core.api_validator import StreamRequest
+from core.config import config
+from core.logger import logger
+from sdk_bridge.decart_client import DecartSovereignBridge
+
+router = APIRouter()
+semaphore = asyncio.Semaphore(10)
+
+class CircuitBreaker:
+    def __init__(self, threshold: int = 5, base_recovery_time: int = 30):
+        self.threshold = threshold
+        self.base_recovery_time = base_recovery_time
+        self.failures = 0
+        self.is_open = False
+        self.last_failure_time = 0
+        self.trip_count = 0
+
+    def can_proceed(self) -> bool:
+        if self.is_open:
+            wait_period = self.base_recovery_time * (2 ** max(self.trip_count - 1, 0))
+            if time.time() - self.last_failure_time > wait_period:
+                logger.info(f"Circuit Breaker: Half-Open (wait={wait_period}s)")
+                return True
+            return False
+        return True
+
+    def record_failure(self):
+        self.failures += 1
+        if self.failures >= self.threshold:
+            if not self.is_open:
+                self.trip_count += 1
+            self.is_open = True
+            self.last_failure_time = time.time()
+            logger.error(f"Circuit Breaker TRIPPED (trip #{self.trip_count})")
+
+    def record_success(self):
+        self.failures = 0
+        self.is_open = False
+        self.trip_count = 0
+
+circuit = CircuitBreaker()
+
+@router.post("/api/stream")
+async def initiate_stream(req: StreamRequest):
+    if not circuit.can_proceed():
+        raise HTTPException(status_code=503, detail="Sovereign Bridge safety lock active (Circuit Open)")
+
+    async with semaphore:
+        bridge = DecartSovereignBridge(api_key=config.DECART_API_KEY)
+        try:
+            stream = await bridge.stream_with_conditions(
+                prompt=req.prompt,
+                fps=req.fps,
+                duration=req.duration,
+                conditioning=req.conditioning_payload,
+            )
+            circuit.record_success()
+
+            async def generator():
+                async for chunk in stream:
+                    yield chunk
+
+            return StreamingResponse(generator(), media_type="video/mp4")
+        except Exception as e:
+            circuit.record_failure()
+            logger.error(f"Routing failure in Sovereign Realm: {e}")
+            raise HTTPException(status_code=503, detail="Divine Engine routing error")
+PY
+
+echo "Scaffold complete at $APP_DIR"


### PR DESCRIPTION
### Motivation

- Introduce a new Sovereign Grace scaffold to host a streaming integration with the Decart sovereign bridge and related modules.
- Provide a resilient streaming API endpoint that protects the Decart bridge via concurrency limiting and a circuit breaker to prevent cascading failures.

### Description

- Add `server/scripts/generate_sovereign_king.sh` which creates the `lucy21-sovereign-king` app layout and initializes `core`, `pro`, `sdk_bridge`, `docs`, and `telemetry` directories and log files.
- Generate `core/api_router.py` implementing a FastAPI `APIRouter` with a semaphore (`10` concurrent slots) and a `CircuitBreaker` class supporting failure counting, exponential backoff recovery, and trip counting.
- Route `POST /api/stream` uses `DecartSovereignBridge.stream_with_conditions` with `StreamRequest` input and returns a `StreamingResponse` of `video/mp4`, and it raises `HTTPException(status_code=503)` on circuit-open or routing errors while logging failures.
- Ensure telemetry placeholders `telemetry/requests.log` and `telemetry/errors.log` are created and the script is executable.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a31066d8833080bd6c77afded283)